### PR TITLE
Change react-bootstrap transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Use [`babel-plugin-transform-imports`](https://www.npmjs.com/package/babel-plugi
   "plugins": [
     ["transform-imports", {
       "react-bootstrap": {
-        "transform": "react-bootstrap/lib/${member}",
+        "transform": "react-bootstrap/es/${member}",
         "preventFullImport": true
       }
     }]


### PR DESCRIPTION
You can use transform-imports to load the react-bootstrap es version instead of the lib to have better access to tree shaking.
