### PR TITLE
add goober alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,10 @@ To see how it works, check [the `babel-plugin-transform-imports` section ⤵️]
 
 There’s [`babel-plugin-styled-components`](https://github.com/styled-components/babel-plugin-styled-components) that minifies the CSS code you write with `styled-components`. See [the minification docs](https://www.styled-components.com/docs/tooling#minification).
 
+### Smaller alternative
+
+You can consider using [`goober`](https://github.com/cristianbote/goober), this library adds 1kb and offers the same syntax as `styled-components` through the use of a [babel-plugin](https://github.com/cristianbote/goober/tree/master/packages/babel-plugin-transform-goober).
+
 ## whatwg-fetch
 
 `whatwg-fetch` is a complete `window.fetch()` polyfill. [npm package](https://www.npmjs.com/package/whatwg-fetch)

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ There’s [`babel-plugin-styled-components`](https://github.com/styled-component
 
 ### Smaller alternative
 
-> ✅ Safe to use by default / How to enable is ↓ / Added by [@iamakulov](https://twitter.com/iamakulov)
+> ✅ Safe to use by default / How to enable is ↓ / Added by [@JoviDeCroock](https://twitter.com/JoviDec)
 
 Consider using [`goober`](https://github.com/cristianbote/goober), this library adds 1kb and offers the same syntax as `styled-components` through the use of a [babel-plugin](https://github.com/cristianbote/goober/tree/master/packages/babel-plugin-transform-goober).
 

--- a/README.md
+++ b/README.md
@@ -370,7 +370,15 @@ There’s [`babel-plugin-styled-components`](https://github.com/styled-component
 
 ### Smaller alternative
 
-You can consider using [`goober`](https://github.com/cristianbote/goober), this library adds 1kb and offers the same syntax as `styled-components` through the use of a [babel-plugin](https://github.com/cristianbote/goober/tree/master/packages/babel-plugin-transform-goober).
+> ✅ Safe to use by default / How to enable is ↓ / Added by [@iamakulov](https://twitter.com/iamakulov)
+
+Consider using [`goober`](https://github.com/cristianbote/goober), this library adds 1kb and offers the same syntax as `styled-components` through the use of a [babel-plugin](https://github.com/cristianbote/goober/tree/master/packages/babel-plugin-transform-goober).
+
+```sh
+npm i goober babel-plugin-transform-goober
+```
+
+when you add `babel-plugin-transform-goober` to your babel config it allows for the same formatting as `styled-components`, think of `styled.div`, else it will be restricted to `styled('div')`.
 
 ## whatwg-fetch
 


### PR DESCRIPTION
I'd also like to suggest these, what do you think:

Forms: [fielder](https://github.com/andyrichardson/fielder) a new approach or [hooked-form](https://github.com/JoviDeCroock/hooked-form) resembles formik. Both are 2kb
Gql client: [urql](https://github.com/FormidableLabs/urql) alternative to apollo for 8kb (no normalised cache and 14kb with)